### PR TITLE
Add OpenStreetMap project link

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ A curated list of resources for Myanmar Unicode.
 
 ## Applications
 
+* [OpenStreetMap-BurmeseEncoding](https://github.com/bdon/OpenStreetMap-BurmeseEncoding) - project to convert [OpenStreetMap](https://openstreetmap.org) data from Zawgyi to Unicode.
+
 *Mac OSX*
 
 * [Unicode-Zawgyi-Converter](https://github.com/saturngod/Unicode-Zawgyi-Converter/releases) - Unicode <=> Zawgyi Converter for Mac.


### PR DESCRIPTION
Hi, I'm not a Myanmar language reader but am working on a project to consolidate text encoding in OpenStreetMap from Zawgyi to Unicode. This will enable map developers around the world to display text correctly with standard open source fonts.

I hope adding this to your list will attract native-language developers to contribute to the OpenStreetMap project. Thank you!